### PR TITLE
Feat/asset path

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,9 @@ if(CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR)
 	message(FATAL_ERROR "Please use a different build directory than the source directory")
 endif()
 
+# Define asset path for use in the executable
+set(ASSET_PATH ${CMAKE_SOURCE_DIR}/../assets/)
+
 # Add the system type for the config file
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set(SYSTEM_TYPE 1)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ if(CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR)
 	message(FATAL_ERROR "Please use a different build directory than the source directory")
 endif()
 
+
 # Define asset path for use in the executable
 set(ASSET_PATH ${CMAKE_SOURCE_DIR}/../assets/)
 
@@ -61,12 +62,9 @@ endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
 
 message("CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME} ${ADDRESS_WIDTH}")
 
-# Debug by default
+# Debug by default - only runs for single configurations
 if(CMAKE_BUILD_TYPE STREQUAL "")
   set(CMAKE_BUILD_TYPE Debug)
-  set(BUILD_TYPE 0)
-else()
-  set(BUILD_TYPE 1)
 endif()
 
 message("CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
@@ -78,10 +76,10 @@ add_subdirectory(external)
 
 # Define _DEBUG on debug builds
 if (MSVC)
-	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd")
+	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd /DBUILD_TYPE=0")
 elseif(CMAKE_COMPILER_IS_GNUCXX)
-	set(CMAKE_CXX_FLAGS_DEBUG "-Og -D_DEBUG -Wall -g -ggdb -pedantic-errors -Wextra -lprofiler -fsanitize=address -fsanitize=leak -fsanitize=undefined")
-	set(CMAKE_CXX_FLAGS_RELEASE "-O3 -Wall -pedantic-errors -lprofiler -Wextra")
+	set(CMAKE_CXX_FLAGS_DEBUG "-Og -D_DEBUG -DBUILD_TYPE=0 -Wall -g -ggdb -pedantic-errors -Wextra -lprofiler -fsanitize=address -fsanitize=leak -fsanitize=undefined")
+	set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DBUILD_TYPE=1 -Wall -pedantic-errors -lprofiler -Wextra")
 endif(MSVC)
 
 configure_file(

--- a/src/Config.h.in
+++ b/src/Config.h.in
@@ -8,7 +8,6 @@
 
 #define SYSTEM_TYPE @SYSTEM_TYPE@
 #define ADDRESS_WIDTH @ADDRESS_WIDTH@
-#define BUILD_TYPE @BUILD_TYPE@
 
 // Use full asset path for debug builds
 //

--- a/src/Config.h.in
+++ b/src/Config.h.in
@@ -1,4 +1,7 @@
 // Options to generate the Config.h file
+#pragma once
+
+#include <string>
 
 #define VERSION_MAJOR @VERSION_MAJOR@
 #define VERSION_MINOR @VERSION_MINOR@
@@ -6,3 +9,13 @@
 #define SYSTEM_TYPE @SYSTEM_TYPE@
 #define ADDRESS_WIDTH @ADDRESS_WIDTH@
 #define BUILD_TYPE @BUILD_TYPE@
+
+// Use full asset path for debug builds
+//
+// Production builds need to use a relative path so that executables
+// can be deployed on machines without requiring a recompile
+#if(BUILD_TYPE == 0)
+const std::string ASSET_PATH = "@ASSET_PATH@";
+#else
+const std::string ASSET_PATH = "../../assets/";
+#endif

--- a/src/game/Paths.h
+++ b/src/game/Paths.h
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <string>
+#include "Config.h"
 
 /** General Path Locations */
-const std::string ASSET_PATH = "../../assets/";
 const std::string TEXTURE_PATH = ASSET_PATH + "textures/";
 const std::string SHADER_PATH = ASSET_PATH + "shaders/";
 const std::string FONT_PATH = ASSET_PATH + "fonts/";

--- a/src/game/_private/TetradGame.cpp
+++ b/src/game/_private/TetradGame.cpp
@@ -27,7 +27,7 @@ bool TetradGame::Initialize(const GameAttributes& attributes)
 	entity.Add<MovableComponent>();
 	DrawComponent *pDraw = entity.Add<DrawComponent>();
 	pDraw->SetGeometry(ShapeType::PLANE);
-	pDraw->SetTexture("../../assets/textures/Background.tga", TextureType::RGB);
+	pDraw->SetTexture(BACKGROUND_PATH, TextureType::RGB);
 	entity.Add<MaterialComponent>()->SetTimeRate(-0.2f);
 
 	// Create floor
@@ -36,7 +36,7 @@ bool TetradGame::Initialize(const GameAttributes& attributes)
 	entity.Add<MovableComponent>();
 	pDraw = entity.Add<DrawComponent>();
 	pDraw->SetGeometry(ShapeType::PLANE);
-	pDraw->SetTexture("../../assets/textures/Floor.tga", TextureType::RGBA);
+	pDraw->SetTexture(FLOOR_PATH, TextureType::RGBA);
 	entity.Add<MaterialComponent>()->SetTimeRate(-0.75f);
 
 	// Create jumping boxes
@@ -48,7 +48,7 @@ bool TetradGame::Initialize(const GameAttributes& attributes)
 		entity.Add<MovableComponent>();
 		pDraw = entity.Add<DrawComponent>();
 		pDraw->SetGeometry(ShapeType::PLANE);
-		pDraw->SetTexture("../../assets/textures/Black.tga", TextureType::RGB);
+		pDraw->SetTexture(TEXTURE_PATH + "Black.tga", TextureType::RGB);
 		entity.Add<PhysicsComponent>();
 		ObserverComponent* pObserver = entity.Add<ObserverComponent>();
 		pObserver->Subscribe(*m_pInputSystem);
@@ -60,7 +60,7 @@ bool TetradGame::Initialize(const GameAttributes& attributes)
 	entity.Add<TransformComponent>()->Init(glm::vec3(0,0,1));
 	pDraw = entity.Add<DrawComponent>();
 	pDraw->SetGeometry(ShapeType::PLANE);
-	pDraw->SetTexture("../../assets/textures/PauseGradient.tga", TextureType::RGBA);
+	pDraw->SetTexture(PAUSE_BACKGROUND_PATH, TextureType::RGBA);
 	entity.Add<MaterialComponent>()->SetOpacity(0.f);
 	Action_PauseGame::SetFadeScreen(entity);
 


### PR DESCRIPTION
For debug builds, CMake will generate an absolute path to the assets folder, allowing the executable to be placed anywhere while still being able to properly load assets.

Production/Release builds still rely on relative paths, since we want to be able to deploy games without requiring users to compile the project itself. This shouldn't be an issue, as users shouldn't be moving the game executable relative to the assets folder to begin with.